### PR TITLE
Quotes paths during build so they can contain spaces

### DIFF
--- a/build.nu
+++ b/build.nu
@@ -19,7 +19,7 @@ def main [package_file: path = nupm.nuon] {
     let features = $features | input list --multi "select cargo features"
 
    
-    let cmd = $"cargo install --path ($repo_root) --root ($install_root) --features=($features | str join ",")"
+    let cmd = $"cargo install --path \"($repo_root)\" --root \"($install_root)\" --features=($features | str join ",")"
     log info $"building plugin using: (ansi blue)($cmd)(ansi reset)"
     nu -c $cmd
     let ext: string = if ($nu.os-info.name == 'windows') { '.exe' } else { '' }


### PR DESCRIPTION
It looks like there is an installation issue on Mac where the default location of nushell's files is located in a directory that contains a space in its name.

<img width="2980" height="862" alt="image" src="https://github.com/user-attachments/assets/8bda3755-0ffd-489b-812a-8d28cf0d2f56" />

Quoting the parameters seems to resolve the problem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved plugin installation to properly handle repository and installation paths containing spaces in directory names.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->