### PR TITLE
fix: disable OutputStream log on drop

### DIFF
--- a/src/sound_make.rs
+++ b/src/sound_make.rs
@@ -108,9 +108,11 @@ fn sine_wave(
     duration_value: Duration,
     amplify_value: f32,
 ) -> Result<(), LabeledError> {
-    let stream_handle = OutputStreamBuilder::open_default_stream().map_err(|err| {
+    let mut stream_handle = OutputStreamBuilder::open_default_stream().map_err(|err| {
         LabeledError::new(err.to_string()).with_label("audio stream exception", Span::unknown())
     })?;
+
+    stream_handle.log_on_drop(false);
 
     let sink = Sink::connect_new(stream_handle.mixer());
     let source = SineWave::new(frequency_value)


### PR DESCRIPTION
The commands `sound beep` and `sound make` are writting the following line in the console when used:
```
Dropping OutputStream, audio playing through this stream will stop
```

This was due to [the `OutputStream` object that write some log in the errout when dropped](https://docs.rs/rodio/0.21.1/rodio/stream/struct.OutputStream.html#method.log_on_drop).
In this PR, I have disable this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal audio stream management configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->