### PR TITLE
feat: add amplification flag to sound play

### DIFF
--- a/src/sound_make.rs
+++ b/src/sound_make.rs
@@ -23,7 +23,7 @@ impl SimplePluginCommand for SoundMakeCmd {
             .named(
                 "amplify",
                 SyntaxShape::Float,
-                "amplify the sound by given value",
+                "amplify or attenuate the sound by given value (e.g. 0.5 for half volume)",
                 Some('a'),
             )
             .category(Category::Experimental)
@@ -33,6 +33,11 @@ impl SimplePluginCommand for SoundMakeCmd {
             Example {
                 description: "create a simple noise frequency",
                 example: "sound make 1000 200ms",
+                result: None,
+            },
+            Example {
+                description: "create a simple noise frequency with 50% volume",
+                example: "sound make 1000 200ms -a 0.5",
                 result: None,
             },
             Example {


### PR DESCRIPTION
Added the --amplify (or -a) flag to the sound play command. This allows adjusting playback volume, supporting both amplification (e.g., -a 2.0) and attenuation (e.g., -a 0.5).

Key updates:
- Added volume adjustment logic to play_audio in src/audio_player.rs.
- Included usage examples for sound play with the new flag.
- Refined the --amplify description in sound make for consistency and added a corresponding example.