### PR TITLE
fix: `sound meta` failing on Windows with relative paths; consolidate file loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,15 +919,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mp3-duration"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348bdc7300502f0801e5b57c448815713cd843b744ef9bda252a2698fdf90a0f"
-dependencies = [
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,7 +1179,6 @@ dependencies = [
  "chrono",
  "id3",
  "lazy_static",
- "mp3-duration",
  "nu-plugin",
  "nu-protocol",
  "rodio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +514,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_filter"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -665,6 +744,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +772,30 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jiff"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c867c356cc096b33f4981825ab281ecba3db0acefe60329f044c1789d94c6543"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7946b4325269738f270bb55b3c19ab5c5040525f83fd625259422a9d25d9be5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jni"
@@ -1177,6 +1286,7 @@ name = "nu_plugin_audio_hook"
 version = "0.110.0"
 dependencies = [
  "chrono",
+ "env_logger",
  "id3",
  "lazy_static",
  "log",
@@ -1362,6 +1472,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,6 +1539,21 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -2222,6 +2353,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vte"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,6 +1179,7 @@ dependencies = [
  "chrono",
  "id3",
  "lazy_static",
+ "log",
  "nu-plugin",
  "nu-protocol",
  "rodio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ version = "1.16.3"
 [dependencies.lazy_static]
 version = "1.4.0"
 
-[dependencies.mp3-duration]
-version = "0.1.10"
-
 [dependencies.nu-protocol]
 features = ["plugin"]
 version = "0.110.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [dependencies]
 chrono = "0.4.41"
+env_logger = "0.11"
 log = "0.4"
 
 [dependencies.nu-plugin]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [dependencies]
 chrono = "0.4.41"
+log = "0.4"
 
 [dependencies.nu-plugin]
 version = "0.110.0"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ sound play audio.mp3 -a 0.5
 ### Retrieve metadata from an audio file
 
 ```bash
-sound meta audio.mp4
+sound meta audio.mp3
 ```
 
 Example output:
@@ -88,16 +88,16 @@ Example output:
 sound meta set audio.mp3 -k TPE1 -v new-artist
 ```
 
-### Play an MP3 file using its metadata duration
+### Play an audio file using its metadata duration
 
 ```bash
-sound meta audio.mp4 | sound play audio.mp3 -d $in.duration
+sound meta audio.mp3 | sound play audio.mp3 -d $in.duration
 ```
 
 ### List all available ID3 frame names
 
 ```bash
-sound meta list
+sound meta --all
 ```
 
 ---
@@ -181,3 +181,4 @@ You can enable specific features when compiling or installing:
   - `symphonia-mp3` (default) — MP3 decoding.
   - `symphonia-vorbis` — OGG Vorbis decoding.
   - `symphonia-wav` — WAV decoding.
+  

--- a/README.md
+++ b/README.md
@@ -1,50 +1,78 @@
-# 🎵 nu_plugin_audio_hook  
+# nu_plugin_audio_hook
 
-A [Nushell](https://www.nushell.sh/) plugin for generating and playing sounds. Supports beeping, tone generation, metadata manipulation, and playback for multiple audio formats.  
-
----
-
-## ✨ Features  
-
-- **`sound beep`** → Play a simple beep sound.  
-- **`sound make`** → Generate a noise with a given frequency and duration.  
-- **`sound meta`** → Retrieve metadata (duration, artist, album, etc.) from an audio file.  
-- **`sound meta set`** → Modify ID3 metadata frames in an audio file. [More about ID3](https://docs.puddletag.net/source/id3.html).  
-- **`sound play`** → Play an audio file. By default, supports FLAC, WAV, MP3, and OGG. Use the `all-decoders` feature to enable AAC and MP4 playback.  
+A [Nushell](https://www.nushell.sh/) plugin for generating and playing sounds. Supports beeping, tone generation, metadata manipulation, and playback for multiple audio formats.
 
 ---
 
-## 📌 Usage  
+## Features
 
-### **Generate a simple noise**  
+- **`sound beep`** — Play a simple beep sound.
+- **`sound make`** — Generate a noise with a given frequency and duration.
+- **`sound meta`** — Retrieve metadata (duration, artist, album, etc.) from an audio file.
+- **`sound meta set`** — Modify ID3 metadata frames in an audio file. [More about ID3](https://docs.puddletag.net/source/id3.html).
+- **`sound play`** — Play an audio file. By default, supports FLAC, WAV, MP3, and OGG. Use the `all-decoders` feature to enable AAC and MP4 playback.
+
+---
+
+## Usage
+
+### Generate a simple noise
 
 ```bash
 sound make 1000 200ms
-```  
+```
 
-### **Generate a noise sequence**  
+### Generate a noise sequence
 
 ```bash
 [ 300.0, 500.0, 1000.0, 400.0, 600.0 ] | each { |it| sound make $it 150ms }
-```  
+```
 
-### **Play an audio file (first 3 seconds only)**  
+### Generate a noise with 50% volume
+
+```bash
+sound make 1000 200ms -a 0.5
+```
+
+### Save a generated tone to a file
+
+```bash
+sound make 1000 200ms --data | save --raw output.wav
+```
+
+### Play an audio file (first 3 seconds only)
 
 ```bash
 sound play audio.mp3 -d 3sec
-```  
+```
 
-### **Retrieve metadata from an audio file**  
+### Play an audio file with 2x volume
+
+```bash
+sound play audio.mp3 -a 2.0
+```
+
+### Play an audio file with 50% volume
+
+```bash
+sound play audio.mp3 -a 0.5
+```
+
+### Retrieve metadata from an audio file
 
 ```bash
 sound meta audio.mp4
-```  
-
-Example Output:  
-
 ```
+
+Example output:
+
+```nushell
 ╭──────────────┬────────────────────────────╮
+│ size         │ 6.4 MiB                    │
+│ format       │ mp3                        │
 │ duration     │ 4min 5sec 551ms 20µs 408ns │
+│ sample_rate  │ 44100                      │
+│ channels     │ 2                          │
 │ artist       │ SINGER                     │
 │ title        │ TITLE                      │
 │ album        │ ALBUM                      │
@@ -52,105 +80,104 @@ Example Output:
 │ track_no     │ 1                          │
 │ total_tracks │ 1                          │
 ╰──────────────┴────────────────────────────╯
-```  
+```
 
-### **Modify ID3 metadata (change the artist tag)**  
+### Modify ID3 metadata (change the artist tag)
 
 ```bash
 sound meta set audio.mp3 -k TPE1 -v new-artist
-```  
+```
 
-### **Play an MP3 file using its metadata duration**  
+### Play an MP3 file using its metadata duration
 
 ```bash
 sound meta audio.mp4 | sound play audio.mp3 -d $in.duration
-```  
+```
 
-### **List all available ID3 frame names**  
+### List all available ID3 frame names
 
 ```bash
 sound meta list
-```  
+```
 
 ---
 
-## 🔧 Installation  
+## Installation
 
-### (If using GNU/Linux) Install ALSA development package (by distro)
+### Linux: install ALSA development package
 
-**Debian / Ubuntu**
+#### Debian / Ubuntu
 
 ```bash
 sudo apt update
 sudo apt install -y libasound2-dev pkg-config
 ```
 
-**RHEL / CentOS / Rocky / Alma**
+#### RHEL / CentOS / Rocky / Alma
 
 ```bash
 sudo dnf install -y alsa-lib-devel pkgconf-pkg-config
 ```
 
-**Arch Linux**
+#### Arch Linux
 
 ```bash
 sudo pacman -S --needed alsa-lib pkgconf
 ```
 
-**openSUSE**
+#### openSUSE
 
 ```bash
 sudo zypper install alsa-lib-devel pkg-config
 ```
 
-
-### 🚀 Recommended: Using [nupm](https://github.com/nushell/nupm)  
-
-```bash
-git clone https://github.com/FMotalleb/nu_plugin_audio_hook.git  
-nupm install --path nu_plugin_audio_hook -f  
-```  
-
-### 🛠️ Manual Compilation  
+### Recommended: using [nupm](https://github.com/nushell/nupm)
 
 ```bash
-git clone https://github.com/FMotalleb/nu_plugin_audio_hook.git  
-cd nu_plugin_audio_hook  
-cargo build -r --features=all-decoders  
-plugin add target/release/nu_plugin_audio_hook  
-```  
+git clone https://github.com/FMotalleb/nu_plugin_audio_hook.git
+nupm install --path nu_plugin_audio_hook -f
+```
 
-### 📦 Install via Cargo (using git)  
+### Manual compilation
 
 ```bash
-cargo install --git https://github.com/FMotalleb/nu_plugin_audio_hook.git --features=all-decoders  
-plugin add ~/.cargo/bin/nu_plugin_audio_hook  
-```  
+git clone https://github.com/FMotalleb/nu_plugin_audio_hook.git
+cd nu_plugin_audio_hook
+cargo build -r --locked --features=all-decoders
+plugin add target/release/nu_plugin_audio_hook
+```
 
-### 📦 Install via Cargo (crates.io) _Not Recommended_  
->
-> _Since I live in Iran and crates.io often restricts package updates, the version there might be outdated._  
+### Install via Cargo (git)
 
 ```bash
-cargo install nu_plugin_audio_hook --features=all-decoders  
-plugin add ~/.cargo/bin/nu_plugin_audio_hook  
-```  
+cargo install --git https://github.com/FMotalleb/nu_plugin_audio_hook.git --locked --features=all-decoders
+plugin add ~/.cargo/bin/nu_plugin_audio_hook
+```
+
+### Install via Cargo (crates.io) — not recommended
+
+> Since I live in Iran and crates.io often restricts package updates, the version there might be outdated.
+
+```bash
+cargo install nu_plugin_audio_hook --locked --features=all-decoders
+plugin add ~/.cargo/bin/nu_plugin_audio_hook
+```
 
 ---
 
-## 🔍 Supported Features  
+## Supported features
 
-You can enable specific features when compiling or installing:  
+You can enable specific features when compiling or installing:
 
-- **`full`** → Enables all features below.  
-- **`flac`** (default) → FLAC format support.  
-- **`vorbis`** (default) → OGG Vorbis support.  
-- **`wav`** (default) → WAV format support.  
-- **`minimp3`** → MP3 decoding.  
-- **`symphonia-all`** → Enables all Symphonia-based decoders:  
-  - `symphonia-aac` → AAC decoding.  
-  - `symphonia-flac` → FLAC decoding.  
-  - `symphonia-isomp4` → MP4 (audio) decoding.  
-  - `symphonia-mp3` (default) → MP3 decoding.  
-  - `symphonia-vorbis` → OGG Vorbis decoding.  
-  - `symphonia-wav` → WAV decoding.  
+- **`full`** — Enables all features below.
+- **`flac`** (default) — FLAC format support.
+- **`vorbis`** (default) — OGG Vorbis support.
+- **`wav`** (default) — WAV format support.
+- **`minimp3`** — MP3 decoding.
+- **`symphonia-all`** — Enables all Symphonia-based decoders:
+  - `symphonia-aac` — AAC decoding.
+  - `symphonia-flac` — FLAC decoding.
+  - `symphonia-isomp4` — MP4 (audio) decoding.
+  - `symphonia-mp3` (default) — MP3 decoding.
+  - `symphonia-vorbis` — OGG Vorbis decoding.
+  - `symphonia-wav` — WAV decoding.

--- a/src/audio_meta.rs
+++ b/src/audio_meta.rs
@@ -26,7 +26,7 @@ impl SimplePluginCommand for SoundMetaSetCmd {
     }
 
     fn description(&self) -> &str {
-        "set a id3 frame on an audio file"
+        "set an ID3 frame on an audio file"
     }
 
     fn run(
@@ -56,7 +56,7 @@ impl SimplePluginCommand for SoundMetaGetCmd {
     }
 
     fn description(&self) -> &str {
-        "get duration and meta data of an audio file"
+        "get duration and metadata of an audio file"
     }
 
     fn run(

--- a/src/audio_player.rs
+++ b/src/audio_player.rs
@@ -57,7 +57,7 @@ impl SimplePluginCommand for SoundPlayCmd {
         ]
     }
     fn description(&self) -> &str {
-        "play an audio file, by default supports flac,Wav,mp3 and ogg files, install plugin with `all-decoders` feature to include aac and mp4(audio)"
+        "play an audio file, by default supports FLAC, WAV, MP3 and OGG files, install plugin with `all-decoders` feature to include AAC and MP4(audio)"
     }
 
     fn run(

--- a/src/audio_player.rs
+++ b/src/audio_player.rs
@@ -1,11 +1,11 @@
 use chrono::Utc;
-use nu_plugin::{self, EngineInterface, EvaluatedCall, SimplePluginCommand};
-use nu_protocol::{Category, Example, LabeledError, Signature, Span, SyntaxShape, Value};
+use nu_plugin::{EngineInterface, EvaluatedCall, SimplePluginCommand};
+use nu_protocol::{Category, Example, LabeledError, Signature, SyntaxShape, Value};
 use rodio::{source::Source, Decoder, OutputStreamBuilder};
 
-use std::{fs::File, path::PathBuf, str::FromStr, time::Duration};
+use std::time::Duration;
 
-use crate::Sound;
+use crate::{utils::load_file, Sound};
 
 pub struct SoundPlayCmd;
 impl SimplePluginCommand for SoundPlayCmd {
@@ -72,7 +72,7 @@ impl SimplePluginCommand for SoundPlayCmd {
 }
 
 fn play_audio(engine: &EngineInterface, call: &EvaluatedCall) -> Result<(), LabeledError> {
-    let (file_span, file) = load_file(engine, call)?;
+    let (file_span, file, _) = load_file(engine, call)?;
 
     let mut output_stream = match OutputStreamBuilder::open_default_stream() {
         Ok(value) => value,
@@ -124,54 +124,8 @@ fn play_audio(engine: &EngineInterface, call: &EvaluatedCall) -> Result<(), Labe
 fn load_duration_from(call: &EvaluatedCall, name: &str) -> Option<Duration> {
     match call.get_flag_value(name) {
         Some(Value::Duration { val, .. }) => {
-            Some(Duration::from_nanos(u64::from_ne_bytes(val.to_ne_bytes())))
+            Some(Duration::from_nanos(val.try_into().unwrap_or(0)))
         }
         _ => None,
     }
-}
-
-fn load_file(engine: &EngineInterface, call: &EvaluatedCall) -> Result<(Span, File), LabeledError> {
-    let file_path: Value = call.req(0).map_err(|e| {
-        LabeledError::new(e.to_string()).with_label("Expected file path", call.head)
-    })?;
-
-    let span = file_path.span();
-
-    let file_path = match file_path {
-        Value::String { val, .. } => PathBuf::from_str(&val)
-            .map_err(|e| LabeledError::new(e.to_string()).with_label("Invalid path format", span)),
-        _ => Err(LabeledError::new("invalid input").with_label("Expected file path", span)),
-    }?;
-
-    let file_path = resolve_filepath(engine, span, file_path)?;
-
-    let file_handle = File::open(file_path).map_err(|e| {
-        LabeledError::new(e.to_string()).with_label("error trying to open the file", span)
-    })?;
-
-    Ok((span, file_handle))
-}
-
-fn resolve_filepath(
-    engine: &EngineInterface,
-    span: Span,
-    file_path: PathBuf,
-) -> Result<PathBuf, LabeledError> {
-    let file_path = if file_path.is_absolute() {
-        Ok::<PathBuf, LabeledError>(file_path)
-    } else {
-        let current_path = engine.get_current_dir().map_err(|e| {
-            LabeledError::new(e.to_string()).with_label("Could not get current directory", span)
-        })?;
-        let base = PathBuf::from_str(current_path.as_str()).map_err(|e| {
-            LabeledError::new(e.to_string()).with_label(
-                "Could not convert path provided by engine to PathBuf object (issue in nushell)",
-                span,
-            )
-        })?;
-        Ok(base.join(file_path))
-    }?
-    .canonicalize()
-    .map_err(|e| LabeledError::new(e.to_string()).with_label("File not found", span))?;
-    Ok(file_path)
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -64,7 +64,7 @@ lazy_static! {
         ("originalreleasetime", "TDOR"),
         ("releasetime", "TDRL"),
         ("taggingtime", "TDTG"),
-        ("year", "TDRC")
+        ("recordingyear", "TDRC")
     ]);
 }
 pub fn get_meta_records(span: Span) -> Value {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,6 @@ mod audio_player;
 mod constants;
 mod sound;
 mod sound_make;
+mod utils;
 pub use sound::Sound;
 // pub use sound_make::make_sound;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use nu_plugin_audio_hook::Sound;
 
 fn main() {
-    env_logger::init();
+    let _ = env_logger::try_init();
     nu_plugin::serve_plugin(&mut Sound {}, nu_plugin::MsgPackSerializer {})
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use nu_plugin_audio_hook::Sound;
 
 fn main() {
+    env_logger::init();
     nu_plugin::serve_plugin(&mut Sound {}, nu_plugin::MsgPackSerializer {})
 }

--- a/src/sound_make.rs
+++ b/src/sound_make.rs
@@ -53,7 +53,7 @@ impl SimplePluginCommand for SoundMakeCmd {
             },
             Example {
                 description: "save a noise to a file",
-                example: "sound make 1000 200ms --data | save output.wav",
+                example: "sound make 1000 200ms --data | save --raw output.wav",
                 result: None,
             },
         ]

--- a/src/sound_make.rs
+++ b/src/sound_make.rs
@@ -19,7 +19,7 @@ impl SimplePluginCommand for SoundMakeCmd {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::new("sound make")
             .required("Frequency", SyntaxShape::Float, "Frequency of the noise")
-            .required("duration", SyntaxShape::Duration, "duration of the noise")
+            .required("duration", SyntaxShape::Duration, "Duration of the noise")
             .named(
                 "amplify",
                 SyntaxShape::Float,

--- a/src/sound_make.rs
+++ b/src/sound_make.rs
@@ -1,4 +1,4 @@
-use nu_plugin::{self, EvaluatedCall, SimplePluginCommand};
+use nu_plugin::{EvaluatedCall, SimplePluginCommand};
 use nu_protocol::{Category, Example, LabeledError, Signature, Span, SyntaxShape, Value};
 use rodio::source::{SineWave, Source};
 use rodio::{OutputStreamBuilder, Sink};
@@ -26,6 +26,11 @@ impl SimplePluginCommand for SoundMakeCmd {
                 "amplify or attenuate the sound by given value (e.g. 0.5 for half volume)",
                 Some('a'),
             )
+            .switch(
+                "data",
+                "output binary data (WAV) instead of playing",
+                Some('d'),
+            )
             .category(Category::Experimental)
     }
     fn examples(&self) -> Vec<Example<'_>> {
@@ -44,6 +49,11 @@ impl SimplePluginCommand for SoundMakeCmd {
                 description: "create a simple noise sequence",
                 example:
                     "[ 300.0, 500.0,  1000.0, 400.0, 600.0 ] | each { |it| sound make $it 150ms }",
+                result: None,
+            },
+            Example {
+                description: "save a noise to a file",
+                example: "sound make 1000 200ms --data | save output.wav",
                 result: None,
             },
         ]
@@ -99,13 +109,18 @@ impl SimplePluginCommand for SoundBeepCmd {
 }
 
 fn make_sound(call: &EvaluatedCall) -> Result<Value, LabeledError> {
-    let (frequency_value, duration_value, amplify_value) = match load_values(call) {
-        Ok(value) => value,
-        Err(value) => return value,
-    };
+    let (frequency_value, duration_value, amplify_value) = load_values(call)?;
 
-    sine_wave(frequency_value, duration_value, amplify_value)?;
-    Ok(Value::nothing(call.head))
+    if call
+        .has_flag("data")
+        .map_err(|e| LabeledError::new(e.to_string()))?
+    {
+        let wav_data = generate_wav(frequency_value, duration_value, amplify_value)?;
+        Ok(Value::binary(wav_data, call.head))
+    } else {
+        sine_wave(frequency_value, duration_value, amplify_value)?;
+        Ok(Value::nothing(call.head))
+    }
 }
 
 fn sine_wave(
@@ -128,57 +143,93 @@ fn sine_wave(
     Ok(())
 }
 
-fn load_values(call: &EvaluatedCall) -> Result<(f32, Duration, f32), Result<Value, LabeledError>> {
-    let frequency: Value = match call.req(0) {
-        Ok(value) => value,
-        Err(err) => {
-            return Err(Err(LabeledError::new(err.to_string())
-                .with_label("Frequency value not found", call.head)))
-        }
-    };
+fn generate_wav(
+    frequency: f32,
+    duration: Duration,
+    amplify: f32,
+) -> Result<Vec<u8>, LabeledError> {
+    let source = SineWave::new(frequency)
+        .take_duration(duration)
+        .amplify(amplify);
+    let sample_rate = 48000u32;
+    let samples: Vec<i16> = source
+        .map(|s| (s.clamp(-1.0, 1.0) * i16::MAX as f32) as i16)
+        .collect();
+
+    let num_channels = 1u16;
+    let bits_per_sample = 16u16;
+    let byte_rate = sample_rate * num_channels as u32 * bits_per_sample as u32 / 8;
+    let block_align = num_channels * bits_per_sample / 8;
+    let subchunk2_size = samples.len() as u32 * num_channels as u32 * bits_per_sample as u32 / 8;
+    let chunk_size = 36 + subchunk2_size;
+
+    let mut buffer = Vec::with_capacity(44 + subchunk2_size as usize);
+
+    // RIFF header
+    buffer.extend_from_slice(b"RIFF");
+    buffer.extend_from_slice(&chunk_size.to_le_bytes());
+    buffer.extend_from_slice(b"WAVE");
+
+    // fmt subchunk
+    buffer.extend_from_slice(b"fmt ");
+    buffer.extend_from_slice(&16u32.to_le_bytes()); // Subchunk1Size for PCM
+    buffer.extend_from_slice(&1u16.to_le_bytes()); // AudioFormat (1 = PCM)
+    buffer.extend_from_slice(&num_channels.to_le_bytes());
+    buffer.extend_from_slice(&sample_rate.to_le_bytes());
+    buffer.extend_from_slice(&byte_rate.to_le_bytes());
+    buffer.extend_from_slice(&block_align.to_le_bytes());
+    buffer.extend_from_slice(&bits_per_sample.to_le_bytes());
+
+    // data subchunk
+    buffer.extend_from_slice(b"data");
+    buffer.extend_from_slice(&subchunk2_size.to_le_bytes());
+
+    for sample in samples {
+        buffer.extend_from_slice(&sample.to_le_bytes());
+    }
+
+    Ok(buffer)
+}
+
+fn load_values(call: &EvaluatedCall) -> Result<(f32, Duration, f32), LabeledError> {
+    let frequency: Value = call.req(0).map_err(|err| {
+        LabeledError::new(err.to_string()).with_label("Frequency value not found", call.head)
+    })?;
+
     let frequency_value: f32 = match frequency.as_float() {
         Ok(value) => value as f32,
         Err(err) => {
-            return Err(Err(LabeledError::new(err.to_string()).with_label(
+            return Err(LabeledError::new(err.to_string()).with_label(
                 "Frequency value must be of type Float (f32)",
                 frequency.span(),
-            )))
+            ))
         }
     };
-    let duration: Value = match call.req(1) {
-        Ok(value) => value,
-        Err(err) => {
-            return Err(Err(LabeledError::new(err.to_string())
-                .with_label("Duration value not found", call.head)))
-        }
-    };
+    let duration: Value = call.req(1).map_err(|err| {
+        LabeledError::new(err.to_string()).with_label("Duration value not found", call.head)
+    })?;
+
     let duration_value = match duration {
         Value::Duration { val, .. } => Duration::from_nanos(val.try_into().unwrap_or(0)),
         _ => {
-            return Err(Err(LabeledError::new(
-                "cannot parse duration value as Duration",
-            )))
+            return Err(LabeledError::new("cannot parse duration value as Duration")
+                .with_label("Expected duration", duration.span()))
         }
     };
 
     let amplify: Value = match call.get_flag("amplify") {
         Ok(value) => match value {
             Some(value) => value,
-            None => Value::float(1.0, Span::unknown()),
+            None => Value::float(1.0, call.head),
         },
         Err(err) => {
-            return Err(Err(LabeledError::new(err.to_string())
-                .with_label("Duration value not found", call.head)))
+            return Err(LabeledError::new(err.to_string())
+                .with_label("Amplify value error", call.head))
         }
     };
-    let amplify_value: f32 = match amplify.as_float() {
-        Ok(value) => value as f32,
-        Err(err) => {
-            return Err(Err(LabeledError::new(err.to_string()).with_label(
-                "Amplify value must be of type Float (f32)",
-                amplify.span(),
-            )))
-        }
-    };
+    let amplify_value: f32 = amplify.as_float().map_err(|err| {
+        LabeledError::new(err.to_string())
+            .with_label("Amplify value must be of type Float (f32)", amplify.span())
+    })? as f32;
     Ok((frequency_value, duration_value, amplify_value))
 }

--- a/src/sound_make.rs
+++ b/src/sound_make.rs
@@ -151,16 +151,17 @@ fn generate_wav(
     let source = SineWave::new(frequency)
         .take_duration(duration)
         .amplify(amplify);
-    let sample_rate = 48000u32;
+    let sample_rate = source.sample_rate();
+    let num_channels = source.channels();
+
     let samples: Vec<i16> = source
         .map(|s| (s.clamp(-1.0, 1.0) * i16::MAX as f32) as i16)
         .collect();
 
-    let num_channels = 1u16;
     let bits_per_sample = 16u16;
     let byte_rate = sample_rate * num_channels as u32 * bits_per_sample as u32 / 8;
     let block_align = num_channels * bits_per_sample / 8;
-    let subchunk2_size = samples.len() as u32 * num_channels as u32 * bits_per_sample as u32 / 8;
+    let subchunk2_size = samples.len() as u32 * bits_per_sample as u32 / 8;
     let chunk_size = 36 + subchunk2_size;
 
     let mut buffer = Vec::with_capacity(44 + subchunk2_size as usize);
@@ -183,7 +184,6 @@ fn generate_wav(
     // data subchunk
     buffer.extend_from_slice(b"data");
     buffer.extend_from_slice(&subchunk2_size.to_le_bytes());
-
     for sample in samples {
         buffer.extend_from_slice(&sample.to_le_bytes());
     }

--- a/src/sound_make.rs
+++ b/src/sound_make.rs
@@ -226,16 +226,17 @@ fn load_values(call: &EvaluatedCall) -> Result<(f32, Duration, f32), LabeledErro
         LabeledError::new(err.to_string()).with_label("Duration value not found", call.head)
     })?;
 
+    let dur_span = duration.span();
     let duration_value = match duration {
         Value::Duration { val, .. } => {
             if val < 0 {
-                return Err(LabeledError::new("Negative duration").with_label("Negative duration", duration.span()));
+                return Err(LabeledError::new("Negative duration").with_label("Negative duration", dur_span));
             }
             Duration::from_nanos(val as u64)
         }
         _ => {
             return Err(LabeledError::new("cannot parse duration value as Duration")
-                .with_label("Expected duration", duration.span()))
+                .with_label("Expected duration", dur_span))
         }
     };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use nu_plugin::{EngineInterface, EvaluatedCall};
 use nu_protocol::{LabeledError, Span, Value};
-use std::{fs::File, path::PathBuf, str::FromStr};
+use std::{fs::File, path::PathBuf};
 
 pub fn resolve_filepath(
     engine: &EngineInterface,
@@ -13,13 +13,7 @@ pub fn resolve_filepath(
         let current_path = engine.get_current_dir().map_err(|e| {
             LabeledError::new(e.to_string()).with_label("Could not get current directory", span)
         })?;
-        let base = PathBuf::from_str(current_path.as_str()).map_err(|e| {
-            LabeledError::new(e.to_string()).with_label(
-                "Could not convert path provided by engine to PathBuf object (issue in nushell)",
-                span,
-            )
-        })?;
-        Ok(base.join(file_path))
+        Ok(PathBuf::from(current_path).join(file_path))
     }?
     .canonicalize()
     .map_err(|e| LabeledError::new(e.to_string()).with_label("File not found", span))?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,7 +16,7 @@ pub fn resolve_filepath(
         Ok(PathBuf::from(current_path).join(file_path))
     }?
     .canonicalize()
-    .map_err(|e| LabeledError::new(e.to_string()).with_label("File not found", span))?;
+    .map_err(|e| LabeledError::new(e.to_string()).with_label("Failed to canonicalize path", span))?;
     Ok(file_path)
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,57 @@
+use nu_plugin::{EngineInterface, EvaluatedCall};
+use nu_protocol::{LabeledError, Span, Value};
+use std::{fs::File, path::PathBuf, str::FromStr};
+
+pub fn resolve_filepath(
+    engine: &EngineInterface,
+    span: Span,
+    file_path: PathBuf,
+) -> Result<PathBuf, LabeledError> {
+    let file_path = if file_path.is_absolute() {
+        Ok::<PathBuf, LabeledError>(file_path)
+    } else {
+        let current_path = engine.get_current_dir().map_err(|e| {
+            LabeledError::new(e.to_string()).with_label("Could not get current directory", span)
+        })?;
+        let base = PathBuf::from_str(current_path.as_str()).map_err(|e| {
+            LabeledError::new(e.to_string()).with_label(
+                "Could not convert path provided by engine to PathBuf object (issue in nushell)",
+                span,
+            )
+        })?;
+        Ok(base.join(file_path))
+    }?
+    .canonicalize()
+    .map_err(|e| LabeledError::new(e.to_string()).with_label("File not found", span))?;
+    Ok(file_path)
+}
+
+pub fn load_file_path(
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+) -> Result<(Span, PathBuf), LabeledError> {
+    let file_path: Value = call.req(0).map_err(|e| {
+        LabeledError::new(e.to_string()).with_label("Expected file path", call.head)
+    })?;
+
+    let span = file_path.span();
+
+    let file_path = match file_path {
+        Value::String { val, .. } => PathBuf::from(val),
+        _ => return Err(LabeledError::new("invalid input").with_label("Expected file path", span)),
+    };
+
+    let file_path = resolve_filepath(engine, span, file_path)?;
+    Ok((span, file_path))
+}
+
+pub fn load_file(
+    engine: &EngineInterface,
+    call: &EvaluatedCall,
+) -> Result<(Span, File, PathBuf), LabeledError> {
+    let (span, path) = load_file_path(engine, call)?;
+    let file = File::open(&path).map_err(|e| {
+        LabeledError::new(e.to_string()).with_label("error trying to open the file", span)
+    })?;
+    Ok((span, file, path))
+}


### PR DESCRIPTION
Fixes #14

`sound meta "audio.mp3"` throws `The system cannot find the file specified (os error 2)` on Windows even when the file is right there. The plugin process has its own working directory that doesn't match the shell's — pass a relative path to `File::open` and Windows has no idea where to look. Linux usually gets away with it because the working directories tend to line up; Windows doesn't let it slide.

The fix lives in a new `resolve_filepath` helper in `src/utils.rs`. Relative paths get resolved against the shell's actual directory via `engine.get_current_dir()`; absolute paths pass through untouched. The file-opening logic that was copy-pasted across `sound meta`, `sound meta set`, and `sound play` is now pulled into two shared helpers — `load_file_path` and `load_file` — so the fix covers all three commands without repeating itself.

Two correctness bugs fixed while in here:

- `src/constants.rs` — `"year"` was keyed twice in `ID3_HASHMAP`, once to `"TYER"` and once to `"TDRC"`. The second silently dropped the first, so files tagged with the older ID3v2.3 year frame returned nothing with no indication why. The `"TDRC"` entry is now `"recordingyear"`.
- `src/sound_make.rs` — the span was read from `duration` after the match had already moved it. `dur_span` is now captured before the match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --data option to generate and return WAV binary data instead of playing audio.

* **Improvements**
  * Richer audio metadata: size, format, duration (when available), sample rate, channels, and improved tag handling.
  * Centralized file-loading and path resolution with clearer contextual errors.
  * Initialize logging at startup.
  * Minor metadata key normalization.

* **Documentation**
  * Expanded README examples for noise generation, saving WAV data, and metadata usage.

* **Chores**
  * Removed mp3-duration dependency; added logging dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->