### PR TITLE
fix(audio_player): stop progress bar from flickering

### DIFF
--- a/src/audio_player.rs
+++ b/src/audio_player.rs
@@ -402,7 +402,12 @@ fn wait_with_progress(
     if interactive {
         let _ = disable_raw_mode();
     }
-    let _ = execute!(err, Show, MoveToColumn(0), Clear(ClearType::CurrentLine));
+    if header.is_some() {
+        let _ = execute!(err, MoveToColumn(0), Clear(ClearType::CurrentLine));
+        let _ = execute!(err, Show, MoveUp(1), MoveToColumn(0), Clear(ClearType::CurrentLine));
+    } else {
+        let _ = execute!(err, Show, MoveToColumn(0), Clear(ClearType::CurrentLine));
+    }
 
     result
 }


### PR DESCRIPTION
Closes #19 

Two fixes in `render_progress`:

Interleaved `write!/queue!` calls were letting the OS render partial frames before the flush. The whole frame is now buffered and sent in one `write_all`.

The artist/title header was printed once at startup and abandoned — cursor movement around the progress line below it caused visual noise. Both lines are now redrawn together on every frame, using a `first_render` flag to reserve the two-line region on the initial draw.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced visual flicker during playback by batching header and progress updates.
  * Header (track title/artist) now renders reliably and is preserved across updates.
  * Long headers are truncated with an ellipsis to avoid layout issues.
  * Progress indicator and header are updated together for smoother display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->