### PR TITLE
fix: inline dep bump script and pin interprocess to =2.2.1

### DIFF
--- a/.github/workflows/dependency-update.yaml
+++ b/.github/workflows/dependency-update.yaml
@@ -31,10 +31,43 @@ jobs:
         id: upgrade
         shell: nu {0}
         run: |
-          # Pinned to commit 2b1f15507005879c0c4d026390bc8d09d97270f8 (2025-06-25: use crates.io for version lookup)
-          http get https://raw.githubusercontent.com/FMotalleb/nushell_sync_script/2b1f15507005879c0c4d026390bc8d09d97270f8/bump_dependencies.nu
-            | save /tmp/update.nu
-          nu /tmp/update.nu
+          def "gh latest tag" [repo: string]: nothing -> string {
+            http get $"https://api.github.com/repos/($repo)/releases/latest"
+              | get tag_name
+          }
+
+          let plugin_repository = "nushell/nushell"
+          let plugin_version = (try {
+              http get https://crates.io/api/v1/crates/nu-plugin?include=keywords%2Ccategories%2Cdownloads%2Cdefault_version
+                | get versions
+                | first
+                | get num
+            } catch {
+              gh latest tag $plugin_repository
+            })
+
+          let toml = (open Cargo.toml)
+          mut deps = ($toml | get dependencies)
+          let fields = ($toml | get dependencies | columns | where ($it =~ "nu-.*"))
+
+          for i in $fields {
+            $deps = ($deps | update $i ($deps | get $i | update version $plugin_version))
+          }
+
+          $deps = ($deps | update interprocess "=2.2.1")
+
+          $toml
+            | update package ($toml | get package | update version $plugin_version)
+            | update dependencies $deps
+            | save Cargo.toml --force
+
+          open nupm.nuon
+            | update version $plugin_version
+            | save nupm.nuon --force
+
+          cargo update interprocess --precise 2.2.1
+          cargo update
+          cargo build
 
       - name: Update CONTRIBUTORS.md
         run: |

--- a/.github/workflows/dependency-update.yaml
+++ b/.github/workflows/dependency-update.yaml
@@ -29,42 +29,51 @@ jobs:
 
       - name: Upgrade dependencies
         id: upgrade
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: nu {0}
         run: |
           def "gh latest tag" [repo: string]: nothing -> string {
-            http get $"https://api.github.com/repos/($repo)/releases/latest"
+            http get --headers [Authorization $"Bearer ($env.GITHUB_TOKEN)"] $"https://api.github.com/repos/($repo)/releases/latest"
               | get tag_name
           }
 
           let plugin_repository = "nushell/nushell"
           let plugin_version = (try {
               http get https://crates.io/api/v1/crates/nu-plugin?include=keywords%2Ccategories%2Cdownloads%2Cdefault_version
-                | get versions
-                | first
-                | get num
+                | get crate.default_version
             } catch {
               gh latest tag $plugin_repository
             })
           let sanitized_plugin_version = ($plugin_version | str replace --regex "^v" "")
 
-          let toml = (open Cargo.toml)
-          mut deps = ($toml | get dependencies)
-          let fields = ($toml | get dependencies | columns | where ($it =~ "nu-.*"))
+          mut content = (open Cargo.toml --raw)
 
-          for i in $fields {
-            $deps = ($deps | update $i ($deps | get $i | update version $sanitized_plugin_version))
+          # Update package version
+          $content = ($content | str replace --regex '(?m)^version\s*=\s*".*?"' $"version = \"($sanitized_plugin_version)\"" --range 0..1)
+
+          let toml_data = (open Cargo.toml)
+          let nu_deps = ($toml_data.dependencies | columns | where ($it =~ "^nu-.*"))
+
+          for dep in $nu_deps {
+            $content = ($content | str replace --regex $"(?m)^($dep)\\s*=\\s*\".*?\"" $"${1}\"($sanitized_plugin_version)\"")
+            $content = ($content | str replace --regex $"(?s)(\[dependencies\.($dep)\][^\[]*?version\\s*=\\s*)\".*?\"" $"${1}\"($sanitized_plugin_version)\"")
+            $content = ($content | str replace --regex $"(?m)^($dep)\\s*=.*version\\s*=\\s*\"[^\"]+\"" $"${1}\"($sanitized_plugin_version)\"")
           }
 
-          $deps = ($deps | update interprocess "=2.2.1")
+          let inter_val = ($toml_data.dependencies | get -i interprocess)
+          if ($inter_val | describe | str starts-with "record") {
+              $content = ($content | str replace --regex '(?s)(\[dependencies\.interprocess\][^\[]*?version\s*=\s*)".*?"' '${1}"=2.2.1"')
+              $content = ($content | str replace --regex '(?m)^(interprocess\s*=.*version\s*=\s*)".*?"' '${1}"=2.2.1"')
+          } else {
+              $content = ($content | str replace --regex '(?m)^interprocess\s*=\s*".*?"' 'interprocess = "=2.2.1"')
+          }
 
-          $toml
-            | update package ($toml | get package | update version $sanitized_plugin_version)
-            | update dependencies $deps
-            | save Cargo.toml --force
+          $content | save --force Cargo.toml
 
-          open nupm.nuon
-            | update version $sanitized_plugin_version
-            | save nupm.nuon --force
+          open nupm.nuon --raw
+            | str replace --regex '(\s*version:\s*)".*?"' $"${1}\"($sanitized_plugin_version)\""
+            | save --force nupm.nuon
 
           cargo update interprocess --precise 2.2.1
           cargo update

--- a/.github/workflows/dependency-update.yaml
+++ b/.github/workflows/dependency-update.yaml
@@ -45,24 +45,25 @@ jobs:
             } catch {
               gh latest tag $plugin_repository
             })
+          let sanitized_plugin_version = ($plugin_version | str replace --regex "^v" "")
 
           let toml = (open Cargo.toml)
           mut deps = ($toml | get dependencies)
           let fields = ($toml | get dependencies | columns | where ($it =~ "nu-.*"))
 
           for i in $fields {
-            $deps = ($deps | update $i ($deps | get $i | update version $plugin_version))
+            $deps = ($deps | update $i ($deps | get $i | update version $sanitized_plugin_version))
           }
 
           $deps = ($deps | update interprocess "=2.2.1")
 
           $toml
-            | update package ($toml | get package | update version $plugin_version)
+            | update package ($toml | get package | update version $sanitized_plugin_version)
             | update dependencies $deps
             | save Cargo.toml --force
 
           open nupm.nuon
-            | update version $plugin_version
+            | update version $sanitized_plugin_version
             | save nupm.nuon --force
 
           cargo update interprocess --precise 2.2.1

--- a/.github/workflows/dependency-update.yaml
+++ b/.github/workflows/dependency-update.yaml
@@ -68,7 +68,7 @@ jobs:
 
           cargo update interprocess --precise 2.2.1
           cargo update
-          cargo build
+          cargo check
 
       - name: Update CONTRIBUTORS.md
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.2.3"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d941b405bd2322993887859a8ee6ac9134945a24ec5ec763a8a962fc64dfec2d"
+checksum = "d2f4e4a06d42fab3e85ab1b419ad32b09eab58b901d40c57935ff92db3287a13"
 dependencies = [
  "doctest-file",
  "libc",
@@ -1289,6 +1289,7 @@ dependencies = [
  "crossterm",
  "env_logger",
  "id3",
+ "interprocess",
  "log",
  "nu-plugin",
  "nu-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ authors-file = "AUTHORS"
 chrono = "0.4.41"
 env_logger = "0.11"
 log = "0.4"
+interprocess = "=2.2.1"
 
 [dependencies.crossterm]
 version = "0.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ authors-file = "AUTHORS"
 chrono = "0.4.41"
 env_logger = "0.11"
 log = "0.4"
-interprocess = "=2.2.1"
+interprocess = "=2.2.1" # TODO: remove once nu-plugin-core no longer depends on interprocess <2.3
 
 [dependencies.crossterm]
 version = "0.29"


### PR DESCRIPTION
Closes #24 

The dependency update workflow was failing because the external bump script it downloads was updating `interprocess` past `2.2.1`, which breaks `nu-plugin-core 0.110.0`. That crate uses `interprocess::local_socket::traits::ListenerNonblockingMode`, a path removed in `2.3.x`.

The external script calls `cargo build` at the end, so there's no way to patch things after it runs. This PR drops the downloaded script entirely and inlines the same logic directly in the workflow, with two changes:

1. After updating `nu-*` deps, the `interprocess` version is explicitly reset to `=2.2.1` before `Cargo.toml` is saved.
2. `cargo update interprocess --precise 2.2.1` runs before the general `cargo update` so the lock file also stays pinned.

Once nushell fixes the import path in `nu-plugin-core`, the pin can be removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned the interprocess dependency to 2.2.1 to ensure compatibility.
  * Reworked the automated dependency updater: it now dynamically resolves and applies plugin versions, updates package metadata, and runs dependency updates and a full build/check as part of CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->